### PR TITLE
fix/get_response accept strings

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -428,9 +428,7 @@ class MycroftSkill:
         validator = validator or validator_default
 
         # Speak query and wait for user response
-        dialog_exists = self.dialog_renderer.render(dialog, data)
-        print(dialog_exists)
-        if dialog_exists:
+        if dialog:
             self.speak_dialog(dialog, data, expect_response=True, wait=True)
         else:
             self.bus.emit(Message('mycroft.mic.listen'))


### PR DESCRIPTION
there was a unnecessary check for self.dialog_renderer that was throwing an error unless a .dialog file existed