### PR TITLE
Feat/lingua nostra - default_tz

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -38,6 +38,7 @@ from mycroft.util import (
     wait_for_exit_signal
 )
 from mycroft.util.lang import set_default_lang
+from mycroft.util.time import set_default_tz
 from mycroft.util.log import LOG
 from mycroft.skills.core import FallbackSkill
 from mycroft.skills.event_scheduler import EventScheduler
@@ -191,6 +192,9 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     config = Configuration.get()
     # Set the active lang to match the configured one
     set_default_lang(config.get('lang', 'en-us'))
+
+    # Set the default timezone to match the configured one
+    set_default_tz()
 
     # Connect this process to the Mycroft message bus
     bus = _start_message_bus_client()

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -18,6 +18,7 @@ import time
 
 from mycroft.configuration import Configuration
 from mycroft.util.lang import set_default_lang
+from mycroft.util.time import set_default_tz
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
@@ -156,7 +157,8 @@ class IntentService:
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
         lang = _get_message_lang(message)
-        set_default_lang(lang)
+        set_default_lang(lang)  # restore default lang
+        set_default_tz()  # restore default timezone
         for skill in copy(self.active_skills):
             self.do_converse(None, skill[0], lang, message)
 
@@ -277,6 +279,7 @@ class IntentService:
         try:
             lang = _get_message_lang(message)
             set_default_lang(lang)
+            set_default_tz()  # set default timezone
 
             utterances = message.data.get('utterances', [])
             combined = _normalize_all_utterances(utterances)

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -28,7 +28,7 @@ from .settings import SkillSettingsDownloader
 from .skill_loader import SkillLoader
 from .skill_updater import SkillUpdater
 
-from lingua_franca import load_languages, set_default_lang
+from lingua_nostra import load_languages, set_default_lang
 
 SKILL_MAIN_MODULE = '__init__.py'
 

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -29,9 +29,9 @@ import warnings
 from calendar import leapdays
 from enum import Enum
 
-from lingua_franca import get_default_lang
+from lingua_nostra import get_default_lang
 # These are the main functions we are using lingua franca to provide
-from lingua_franca.format import (NUMBER_TUPLE, DateTimeFormat, join_list,
+from lingua_nostra.format import (NUMBER_TUPLE, DateTimeFormat, join_list,
                                   date_time_format, expand_options,
                                   _translate_word,
                                   nice_number, nice_time, pronounce_number,

--- a/mycroft/util/lang.py
+++ b/mycroft/util/lang.py
@@ -19,4 +19,4 @@ The mycroft.util.lang module provides the main interface for setting up the
 lingua-franca (https://github.com/mycroftai/lingua-franca) selected language
 """
 
-from lingua_franca import set_default_lang, get_default_lang
+from lingua_nostra import set_default_lang, get_default_lang

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -30,11 +30,11 @@ The module does implement some useful functions like basic fuzzy matchin.
 from difflib import SequenceMatcher
 from warnings import warn
 
-import lingua_franca.parse
-from lingua_franca import get_default_lang, get_primary_lang_code
-from lingua_franca.parse import extract_number, extract_numbers, \
+
+from lingua_nostra import get_default_lang, get_primary_lang_code
+from lingua_nostra.parse import extract_number, extract_numbers, \
     extract_duration, get_gender, normalize
-from lingua_franca.parse import extract_datetime as lf_extract_datetime
+from lingua_nostra.parse import extract_datetime as lf_extract_datetime
 
 from .time import now_local
 from .log import LOG

--- a/mycroft/util/time.py
+++ b/mycroft/util/time.py
@@ -19,6 +19,14 @@ may not match the system locale.
 """
 from datetime import datetime
 from dateutil.tz import gettz, tzlocal
+from lingua_nostra.time import set_default_tz as _set_default_tz, now_utc, \
+    now_local, to_local, to_utc
+
+
+def set_default_tz(tz=None):
+    if not tz:
+        tz = default_timezone()
+    _set_default_tz(tz)
 
 
 def default_timezone():
@@ -43,59 +51,6 @@ def default_timezone():
     except Exception:
         # Just go with system default timezone
         return tzlocal()
-
-
-def now_utc():
-    """Retrieve the current time in UTC
-
-    Returns:
-        (datetime): The current time in Universal Time, aka GMT
-    """
-    return to_utc(datetime.utcnow())
-
-
-def now_local(tz=None):
-    """Retrieve the current time
-
-    Arguments:
-        tz (datetime.tzinfo, optional): Timezone, default to user's settings
-
-    Returns:
-        (datetime): The current time
-    """
-    if not tz:
-        tz = default_timezone()
-    return datetime.now(tz)
-
-
-def to_utc(dt):
-    """Convert a datetime with timezone info to a UTC datetime
-
-    Arguments:
-        dt (datetime): A datetime (presumably in some local zone)
-    Returns:
-        (datetime): time converted to UTC
-    """
-    tzUTC = gettz("UTC")
-    if dt.tzinfo:
-        return dt.astimezone(tzUTC)
-    else:
-        return dt.replace(tzinfo=gettz("UTC")).astimezone(tzUTC)
-
-
-def to_local(dt):
-    """Convert a datetime to the user's local timezone
-
-    Arguments:
-        dt (datetime): A datetime (if no timezone, defaults to UTC)
-    Returns:
-        (datetime): time converted to the local timezone
-    """
-    tz = default_timezone()
-    if dt.tzinfo:
-        return dt.astimezone(tz)
-    else:
-        return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)
 
 
 def to_system(dt):

--- a/mycroft/util/time.py
+++ b/mycroft/util/time.py
@@ -17,10 +17,9 @@
 system. This time is based on the setting in the Mycroft config and may or
 may not match the system locale.
 """
-from datetime import datetime
-from dateutil.tz import gettz, tzlocal
+from dateutil.tz import gettz
 from lingua_nostra.time import set_default_tz as _set_default_tz, now_utc, \
-    now_local, to_local, to_utc
+    now_local, to_local, to_utc, to_system, default_timezone as _default_tz
 
 
 def set_default_tz(tz=None):
@@ -50,19 +49,5 @@ def default_timezone():
         return gettz(code)
     except Exception:
         # Just go with system default timezone
-        return tzlocal()
+        return _default_tz()
 
-
-def to_system(dt):
-    """Convert a datetime to the system's local timezone
-
-    Arguments:
-        dt (datetime): A datetime (if no timezone, assumed to be UTC)
-    Returns:
-        (datetime): time converted to the operation system's timezone
-    """
-    tz = tzlocal()
-    if dt.tzinfo:
-        return dt.astimezone(tz)
-    else:
-        return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,10 +1,8 @@
 requests
 pyee
-#lingua-franca
-git+https://github.com/HelloChatterbox/lingua-franca@0.4.0rc1
+git+https://github.com/HelloChatterbox/lingua-nostra
 pyxdg
-#mycroft-messagebus-client
-git+https://github.com/HelloChatterbox/mycroft-messagebus-client
+mycroft-messagebus-client>=0.9.1
 inflection
 psutil
 fasteners

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,7 +15,7 @@ python-dateutil==2.6.0
 fasteners==0.14.1
 PyYAML==5.1.2
 
-lingua-franca==0.2.2
+git+https://github.com/HelloChatterbox/lingua-nostra
 msm==0.8.8
 msk==0.3.16
 adapt-parser==0.3.7
@@ -25,4 +25,4 @@ padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
 pyxdg==0.26
-git+https://github.com/MycroftAI/mycroft-messagebus-client
+mycroft-messagebus-client>=0.9.1


### PR DESCRIPTION
migrates from lingua_franca to https://github.com/HelloChatterbox/lingua-nostra

ensures proper timezone support, relates to https://github.com/HelloChatterbox/mycroft-lib/pull/2 and https://github.com/MycroftAI/lingua-franca/pull/180

this does not get us out of sync with mycroft unless https://github.com/MycroftAI/lingua-franca/pull/180 is rejected

some skills might break if they can't handle timezone aware datetimes, but we should not include bugs in mycroft-lib because of bugs in skills