### PR TITLE
patch/deactivate_audio_backends

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -129,7 +129,6 @@ def load_internal_services(config, bus, path=None):
     service_directories = get_services(path)
     service = []
     for descriptor in service_directories:
-        LOG.info('Loading ' + descriptor['name'])
         try:
             service_module = descriptor['info']['mod']
             spec = descriptor['info']['spec']
@@ -142,6 +141,7 @@ def load_internal_services(config, bus, path=None):
         else:
             s = setup_service(service_module, config, bus)
             if s:
+                LOG.info('Loaded ' + descriptor['name'])
                 service += s
 
     return service

--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -159,6 +159,14 @@ def autodetect(config, bus):
     """
         Autodetect chromecasts on the network and create backends for each
     """
+    backends = config.get('backends', [])
+
+    if len([b for b in backends
+            if backends[b]['type'] == 'chromecast' and
+               backends[b].get('active', False)]) > 0:
+        # TODO allow enabling/disabling by name
+        return []
+
     casts = pychromecast.get_chromecasts(timeout=5, tries=2, retry_wait=2)
     ret = []
     for c in casts:

--- a/mycroft/audio/services/mopidy/__init__.py
+++ b/mycroft/audio/services/mopidy/__init__.py
@@ -124,6 +124,6 @@ def load_service(base_config, bus):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
                 if backends[b]['type'] == 'mopidy' and
-                backends[b].get('active', True)]
+                backends[b].get('active', False)]
     instances = [MopidyService(s[1], bus, s[0]) for s in services]
     return instances

--- a/mycroft/audio/services/mplayer/__init__.py
+++ b/mycroft/audio/services/mplayer/__init__.py
@@ -14,12 +14,6 @@
 #
 from mycroft.audio.services import AudioBackend
 from mycroft.util.log import LOG
-try:
-    from py_mplayer import MplayerCtrl
-except ImportError:
-    LOG.error("install py_mplayer with "
-              "pip install git+https://github.com/JarbasAl/py_mplayer")
-    raise
 
 
 class MPlayerService(AudioBackend):
@@ -35,6 +29,12 @@ class MPlayerService(AudioBackend):
         self.index = 0
         self.normal_volume = None
         self.tracks = []
+        try:
+            from py_mplayer import MplayerCtrl
+        except ImportError:
+            LOG.error("install py_mplayer with "
+                      "pip install git+https://github.com/JarbasAl/py_mplayer")
+            raise
         self.mpc = MplayerCtrl()
 
     def supported_uris(self):
@@ -125,6 +125,6 @@ def load_service(base_config, emitter):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
                 if backends[b]['type'] == 'mplayer' and
-                backends[b].get("active", True)]
+                backends[b].get("active", False)]
     instances = [MPlayerService(s[1], emitter, s[0]) for s in services]
     return instances

--- a/mycroft/audio/services/simple/__init__.py
+++ b/mycroft/audio/services/simple/__init__.py
@@ -243,6 +243,6 @@ def load_service(base_config, bus):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
                 if backends[b]['type'] == 'simple' and
-                backends[b].get('active', True)]
+                backends[b].get('active', False)]
     instances = [SimpleAudioService(s[1], bus, s[0]) for s in services]
     return instances

--- a/mycroft/audio/services/vlc/__init__.py
+++ b/mycroft/audio/services/vlc/__init__.py
@@ -173,6 +173,6 @@ def load_service(base_config, bus):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
                 if backends[b]['type'] == 'vlc' and
-                backends[b].get('active', True)]
+                backends[b].get('active', False)]
     instances = [VlcService(s[1], bus, s[0]) for s in services]
     return instances


### PR DESCRIPTION
mplayer/mopidy/chromecast are now disabled by default, using them requires editing the .conf

previously all audio backends were always loaded, now only vlc and simple are active by default

chromecast did not support the `active` flag, it can now also be deactivated

audio service loading logs have also been cleaned up