### PR TITLE
dont raise exception on directory creation error

### DIFF
--- a/mycroft/configuration/locations.py
+++ b/mycroft/configuration/locations.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from time import sleep
 from os.path import join, dirname, expanduser, exists
 
 DEFAULT_CONFIG = join(dirname(__file__), 'mycroft.conf')
@@ -31,7 +32,16 @@ def __ensure_folder_exists(path):
      """
     directory = dirname(path)
     if not exists(directory):
-        os.makedirs(directory)
+        try:
+            os.makedirs(directory)
+        except:
+            sleep(0.2)
+            if not exists(directory):
+                try:
+                    os.makedirs(directory)
+                except Exception as e:
+                    from mycroft.util.log import LOG
+                    LOG.exception(e)
 
 
 __ensure_folder_exists(WEB_CONFIG_CACHE)


### PR DESCRIPTION
there is an unlikely situation that 2 separate processes will try to create the default directories at same time, this attempts to account for that instead of raising an exception

```
  File "/usr/local/lib/python3.7/site-packages/mycroft/util/log.py", line 37, in <module>
    from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG
  File "/usr/local/lib/python3.7/site-packages/mycroft/configuration/locations.py", line 38, in <module>
    __ensure_folder_exists(USER_CONFIG)
  File "/usr/local/lib/python3.7/site-packages/mycroft/configuration/locations.py", line 34, in __ensure_folder_exists
    os.makedirs(directory)
  File "/usr/local/lib/python3.7/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/root/.mycroft'

```