### PR TITLE
Patch/no fallback priority limit

### DIFF
--- a/mycroft/skills/fallback_skill.py
+++ b/mycroft/skills/fallback_skill.py
@@ -61,7 +61,9 @@ class FallbackSkill(MycroftSkill):
         """Goes through all fallback handlers until one returns True"""
 
         def handler(message):
-            start, stop = message.data.get('fallback_range', (0, 101))
+            # No hard limit to 100, while not officially supported
+            # mycroft-lib can handle fallback priorities up to 999
+            start, stop = message.data.get('fallback_range', (0, 999))
             # indicate fallback handling start
             LOG.debug('Checking fallbacks in range '
                       '{} - {}'.format(start, stop))

--- a/mycroft/skills/fallback_skill.py
+++ b/mycroft/skills/fallback_skill.py
@@ -63,7 +63,7 @@ class FallbackSkill(MycroftSkill):
         def handler(message):
             # No hard limit to 100, while not officially supported
             # mycroft-lib can handle fallback priorities up to 999
-            start, stop = message.data.get('fallback_range', (0, 999))
+            start, stop = message.data.get('fallback_range', (0, 1000))
             # indicate fallback handling start
             LOG.debug('Checking fallbacks in range '
                       '{} - {}'.format(start, stop))


### PR DESCRIPTION
 No hard limit at priority 100, while not officially supported mycroft-lib can handle fallback priorities up to 999

previously fallback with priority > 100 would simply be ignored, now a skill is allowed to partially "overflow"