### PR TITLE
patch/dummy_enclosure

### DIFF
--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -51,11 +51,13 @@ def create_enclosure(platform):
         LOG.info("Creating Mark II Enclosure")
         from mycroft.client.enclosure.mark2 import EnclosureMark2
         enclosure = EnclosureMark2()
+    elif platform and platform != "generic":
+        LOG.info("Creating dummy enclosure, platform='{}'".format(platform))
+        from mycroft.client.enclosure.base import Enclosure
+        enclosure = Enclosure()
     else:
+        # mycroft-core style generic enclosure, does more than it should!
         LOG.info("Creating generic enclosure, platform='{}'".format(platform))
-
-        # TODO: Mechanism to load from elsewhere.  E.g. read a script path from
-        # the mycroft.conf, then load/launch that script.
         from mycroft.client.enclosure.generic import EnclosureGeneric
         enclosure = EnclosureGeneric()
 

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import asyncio
-
+import time
 from collections import namedtuple
 from threading import Lock
 
@@ -104,6 +104,44 @@ class Enclosure:
         self.bus.on("gui.clear.namespace", self.on_gui_delete_namespace)
         self.bus.on("gui.event.send", self.on_gui_send_event)
         self.bus.on("gui.status.request", self.handle_gui_status_request)
+
+        # TODO: this requires the Enclosure to be up and running before the
+        # training is complete.
+        self.bus.on('mycroft.skills.trained', self.is_device_ready)
+
+    def is_device_ready(self, message):
+        is_ready = False
+        # Bus service assumed to be alive if messages sent and received
+        # Enclosure assumed to be alive if this method is running
+        services = {'audio': False, 'speech': False, 'skills': False}
+        start = time.monotonic()
+        while not is_ready:
+            is_ready = self.check_services_ready(services)
+            if is_ready:
+                break
+            elif time.monotonic() - start >= 60:
+                raise Exception('Timeout waiting for services start.')
+            else:
+                time.sleep(3)
+
+        if is_ready:
+            LOG.info("Mycroft is all loaded and ready to roll!")
+            self.bus.emit(Message('mycroft.ready'))
+
+        return is_ready
+
+    def check_services_ready(self, services):
+        """Report if all specified services are ready.
+
+        services (iterable): service names to check.
+        """
+        for ser in services:
+            services[ser] = False
+            response = self.bus.wait_for_response(Message(
+                'mycroft.{}.is_ready'.format(ser)))
+            if response and response.data['status']:
+                services[ser] = True
+        return all([services[ser] for ser in services])
 
     def run(self):
         """Start the Enclosure after it has been constructed."""

--- a/mycroft/client/enclosure/generic/__init__.py
+++ b/mycroft/client/enclosure/generic/__init__.py
@@ -42,9 +42,6 @@ class EnclosureGeneric(Enclosure):
 
         # Notifications from mycroft-core
         self.bus.on('enclosure.notify.no_internet', self.on_no_internet)
-        # TODO: this requires the Enclosure to be up and running before the
-        # training is complete.
-        self.bus.on('mycroft.skills.trained', self.is_device_ready)
 
         # initiates the web sockets on display manager
         # NOTE: this is a temporary place to connect the display manager
@@ -57,40 +54,6 @@ class EnclosureGeneric(Enclosure):
             # receive the "speak".  This was sometimes happening too
             # quickly and the user wasn't notified what to do.
             Timer(5, self._do_net_check).start()
-
-    def is_device_ready(self, message):
-        is_ready = False
-        # Bus service assumed to be alive if messages sent and received
-        # Enclosure assumed to be alive if this method is running
-        services = {'audio': False, 'speech': False, 'skills': False}
-        start = time.monotonic()
-        while not is_ready:
-            is_ready = self.check_services_ready(services)
-            if is_ready:
-                break
-            elif time.monotonic() - start >= 60:
-                raise Exception('Timeout waiting for services start.')
-            else:
-                time.sleep(3)
-
-        if is_ready:
-            LOG.info("Mycroft is all loaded and ready to roll!")
-            self.bus.emit(Message('mycroft.ready'))
-
-        return is_ready
-
-    def check_services_ready(self, services):
-        """Report if all specified services are ready.
-
-        services (iterable): service names to check.
-        """
-        for ser in services:
-            services[ser] = False
-            response = self.bus.wait_for_response(Message(
-                                'mycroft.{}.is_ready'.format(ser)))
-            if response and response.data['status']:
-                services[ser] = True
-        return all([services[ser] for ser in services])
 
     def on_no_internet(self, event=None):
         if connected():


### PR DESCRIPTION
- old style mycroft generic enclosure can be used by setting `enclosure.platform` to `None` or `"generic"`
- default dummy enclosure no longer does the pairing/wifi check dance