### PR TITLE
patch/dont require tornado installed

### DIFF
--- a/mycroft/messagebus/__init__.py
+++ b/mycroft/messagebus/__init__.py
@@ -14,4 +14,4 @@
 from mycroft.messagebus.client.client import MessageBusClient
 from mycroft.messagebus.message import Message
 from mycroft.messagebus.send_func import send
-from mycroft.messagebus.service.event_handler import MessageBusEventHandler
+#from mycroft.messagebus.service.event_handler import MessageBusEventHandler

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mycroft-lib',
-    version="2021.4.2a8",
+    version="2021.4.2a9",
     license='Apache-2.0',
     url='https://github.com/HelloChatterbox/mycroft-lib',
     description='Mycroft packaged as a library',


### PR DESCRIPTION
the exposed MessageBusEventHandler class is mostly unused all over core but drags the tornado requirement, no reason for anyone to import it either so the top level module import was removed