### PR TITLE
patch/ntp_sync

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -241,6 +241,15 @@
     // ??
     "update": true,
 
+    // The NTP sync should only forced on Raspberry Pi based devices.
+    "ntp_sync_on_boot": false,
+
+    // for backwards compat NTP sync is automatically enabled for
+    // ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
+    // to disable forced ntp_sync in official mycroft platforms
+    // set this to false
+    "force_mycroft_ntp": true,
+
     // Run a self test at bootup?
     "test": false
   },

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -58,6 +58,14 @@ class DevicePrimer(object):
     def __init__(self, message_bus_client, config):
         self.bus = message_bus_client
         self.platform = config['enclosure'].get("platform", "unknown")
+
+        # force flag is for backwards compat with regular mycroft-core
+        # assumptions
+        force = config['enclosure'].get("force_mycroft_ntp") and \
+                self.platform in RASPBERRY_PI_PLATFORMS
+
+        self.do_ntp_sync = config['enclosure'].get("ntp_sync_on_boot") or force
+
         self.enclosure = EnclosureAPI(self.bus)
         self.is_paired = False
         self.backend_down = False
@@ -99,7 +107,7 @@ class DevicePrimer(object):
         because it could have a negative impact on other software running on
         that device.
         """
-        if self.platform in RASPBERRY_PI_PLATFORMS:
+        if self.do_ntp_sync:
             LOG.info('Updating the system clock via NTP...')
             if self.is_paired:
                 # Only display time sync message when paired because the prompt


### PR DESCRIPTION
mycroft-core checks a hardcoded list of official raspberry platforms to force a ntp sync on boot

this is bad design and should be configurable at the system level mycroft.conf

for backwards compat old behaviour for hardcoded platforms will work, but different platforms should enable the new parameter in the .conf

if the old behaviour needs to be disabled (using mycroft-lib in one of the official platforms) a new .conf option is also provided


this is known to cause issues at least in [OpenVoiceOS](https://github.com/OpenVoiceOS/OpenVoiceOS/blob/develop/buildroot-external/package/python-mycroft-lib/0001-Fix-enclosure-assumptions.patch#L215)