### PR TITLE
fix/LF+LN_coexisting

### DIFF
--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -29,11 +29,18 @@ import warnings
 from calendar import leapdays
 from enum import Enum
 
-# These are the main functions we are using lingua franca to provide
 # lingua_franca is optional, both lingua_franca and lingua_nostra are supported
+# if both are installed preference is given to LN
+# "setters" will be set in both lbs
+# LN should be functionality equivalent to LF
+# API wont change, but hopefully LN will work better
+# (LN would not exist if it wasn't needed/changes accepted upstream)
+
+
+from mycroft.util.lang import get_default_lang
+
 try:
     try:
-        from lingua_nostra import get_default_lang
         from lingua_nostra.format import (NUMBER_TUPLE, DateTimeFormat,
                                           join_list,
                                           date_time_format, expand_options,
@@ -42,7 +49,6 @@ try:
                                           pronounce_number,
                                           nice_date, nice_date_time, nice_year)
     except ImportError:
-        from lingua_franca import get_default_lang
         # These are the main functions we are using lingua franca to provide
         from lingua_franca.format import (NUMBER_TUPLE, DateTimeFormat,
                                           join_list,
@@ -55,7 +61,6 @@ except ImportError:
     def lingua_franca_error(*args, **kwargs):
         raise ImportError("lingua_franca is not installed")
 
-    from mycroft.util.lang import get_default_lang
     from mycroft.util.bracket_expansion import expand_options
 
     NUMBER_TUPLE, DateTimeFormat = None, None

--- a/mycroft/util/lang.py
+++ b/mycroft/util/lang.py
@@ -1,36 +1,69 @@
-#
-# Copyright 2020 Mycroft AI Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 """
 The mycroft.util.lang module provides the main interface for setting up the
 lingua-franca (https://github.com/mycroftai/lingua-franca) selected language
 """
+
+# we want to support both LF and LN
+# when using the mycroft wrappers this is not an issue, but skills might use
+# either, so mycroft-lib needs to account for this and set the defaults for
+# both libs.
+
+# lingua_franca/lingua_nostra are optional and might not be installed
+# if needed provide dummy methods
+# exceptions should only be raised in the parse and format utils
+
+# TODO improve this, duplicating code is usually bad, consider
+#  supporting only LN and making it a hard requirement, in this case
+#  only skills importing LF would need to worry, the setter methods
+#  should always account for both libs
+
 try:
-    from lingua_franca import set_default_lang, get_default_lang, load_languages
+    import lingua_franca as LF
 except ImportError:
-    _lang = "en-us"
+    LF = None
 
-    def get_default_lang():
-        return _lang
+try:
+    import lingua_nostra as LN
+except ImportError:
+    LN = None
 
-    def set_default_lang(lang):
-        global _lang
-        _lang = lang
-
-    def load_languages(*args, **kwargs):
-        pass
+_lang = "en-us"
 
 
+def get_primary_lang_code():
+    if LN:
+        return LN.get_primary_lang_code()
+    if LF:
+        return LF.get_primary_lang_code()
+    return _lang.split("-")[0]
+
+
+def get_default_lang():
+    if LN:
+        return LN.get_default_lang()
+    if LF:
+        return LF.get_default_lang()
+    return _lang
+
+
+def set_default_lang(lang):
+    global _lang
+    _lang = lang
+    if LN:
+        LN.set_default_lang(lang)
+    if LF:
+        LF.set_default_lang(lang)
+
+
+def load_languages(langs):
+    if LN:
+        LN.load_languages(langs)
+    if LF:
+        LF.load_languages(langs)
+
+
+def load_language(lang):
+    if LN:
+        LN.load_language(lang)
+    if LF:
+        LF.load_language(lang)

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -31,15 +31,22 @@ from difflib import SequenceMatcher
 from warnings import warn
 
 # lingua_franca is optional, both lingua_franca and lingua_nostra are supported
+# if both are installed preference is given to LN
+# "setters" will be set in both lbs
+# LN should be functionality equivalent to LF
+# API wont change, but hopefully LN will work better
+# (LN would not exist if it wasn't needed/changes accepted upstream)
+
+
+from mycroft.util.lang import get_default_lang, get_primary_lang_code
+
 try:
     try:
-        from lingua_nostra import get_default_lang, get_primary_lang_code
         from lingua_nostra.parse import extract_number, extract_numbers, \
             extract_duration, get_gender, normalize
         from lingua_nostra.parse import extract_datetime as lf_extract_datetime
         from lingua_nostra.time import now_local
     except ImportError:
-        from lingua_franca import get_default_lang, get_primary_lang_code
         from lingua_franca.parse import extract_number, extract_numbers, \
             extract_duration, get_gender, normalize
         from lingua_franca.parse import extract_datetime as lf_extract_datetime

--- a/mycroft/util/time.py
+++ b/mycroft/util/time.py
@@ -1,36 +1,42 @@
-#
-# Copyright 2018 Mycroft AI Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 """Time utils for getting and converting datetime objects for the Mycroft
 system. This time is based on the setting in the Mycroft config and may or
 may not match the system locale.
 """
 from datetime import datetime
 from dateutil.tz import gettz, tzlocal
+from mycroft.util.log import LOG
 
-# lingua_franca is optional, both lingua_franca and lingua_nostra are supported
+# we want to support both LF and LN
+# when using the mycroft wrappers this is not an issue, but skills might use
+# either, so mycroft-lib needs to account for this and set the defaults for
+# both libs.
+# if neither LF or LN are installed provide dummy methods
+# exceptions should be raised in the actual functionality,
+# not on loading of core itself
+
+try:
+    import lingua_franca as LF
+except ImportError:
+    LF = None
+
+try:
+    import lingua_nostra as LN
+except ImportError:
+    LN = None
+
 try:
     try:
-        from lingua_nostra.time import now_utc, now_local, to_local, to_utc, \
-            default_timezone as _default_tz
+        from lingua_nostra.time import now_utc, now_local, to_local, to_utc
     except ImportError:
-        from lingua_franca.time import now_utc, now_local, to_local, to_utc, \
-            default_timezone as _default_tz
+        from lingua_franca.time import now_utc, now_local, to_local, to_utc
 except ImportError:
-    def _default_tz():
-        return tzlocal()
+    # lingua_franca/lingua_nostra are optional and should not be needed
+    # because of time utils, only parse and format utils require it
+
+    # TODO improve this, duplicating code is usually bad, consider
+    #  supporting only LN and making it a hard requirement, in this case
+    #  only skills importing LF would need to worry, the setter methods
+    #  should always account for both libs
 
     def now_utc():
         return to_utc(datetime.utcnow())
@@ -60,6 +66,13 @@ except ImportError:
 
 def set_default_tz(tz=None):
     """ placeholder waiting for lingua_nostra version bump """
+    if LN:
+        LN.time.set_default_tz(tz)
+    elif LF:
+        LOG.warning("mycroft-lib is using lingua_franca, it does not support "
+                    "timezones, install lingua_nostra instead, "
+                    "it is a drop in replacement with extra functionality")
+        LOG.error("pip install lingua_nostra")
 
 
 def default_timezone():
@@ -72,18 +85,22 @@ def default_timezone():
         (datetime.tzinfo): Definition of the default timezone
     """
     try:
-        # Obtain from user's configurated settings
+        # Obtain from user's configured settings
         #   location.timezone.code (e.g. "America/Chicago")
         #   location.timezone.name (e.g. "Central Standard Time")
         #   location.timezone.offset (e.g. -21600000)
         from mycroft.configuration import Configuration
         config = Configuration.get()
         code = config["location"]["timezone"]["code"]
-
         return gettz(code)
     except Exception:
+        # Just go with LF/LN default timezone
+        if LN:
+            return LN.time.default_timezone()
+        if LF:
+            return LF.time.default_timezone()
         # Just go with system default timezone
-        return _default_tz()
+        return tzlocal()
 
 
 def to_system(dt):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mycroft-lib',
-    version="2021.4.2a14",
+    version="2021.4.2a15",
     license='Apache-2.0',
     url='https://github.com/HelloChatterbox/mycroft-lib',
     description='Mycroft packaged as a library',
@@ -30,7 +30,7 @@ setup(
                       "requests-futures"],
     extras_require={
         "lingua_franca": ["lingua_franca>=0.3.1"],
-        "lingua_nostra": ["lingua-nostra==0.4.0a2"],
+        "lingua_nostra": ["lingua-nostra>=0.4.0a3"],
         "bus": ["tornado==6.0.3"],
         "enclosure": ["tornado==6.0.3"],
         "skills_minimal": ["mock_msm", "adapt-parser>=0.3.7", "padaos==0.1.9"],


### PR DESCRIPTION
- finish integration of timezone support with LN (was a dummy method until now)
- lingua_franca and lingua_nostra need to be able to coexist
	- skills might be importing one of those libs directly
- mycroft-lib will call property setters (lang/timezone) for both libs if possible
- all other wrapped methods (`mycroft.util.parse` + `mycroft.util.format` + `mycroft.util.time`) will give preference to LN if it is available, use LF otherwise
	- this should be irrelevant for end users since LN is a drop in replacement
