### PR TITLE
offline support

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -94,6 +94,11 @@
 
   // General skill values
   "skills": {
+    // don't start loading skills until internet is detected
+    // this config value is not present in mycroft-core ()internet is required)
+    // mycroft-lib expects that some instances will be running fully offline
+    "wait_for_internet": true,
+
     "msm": {
       // Relative to "data_dir"
       "directory": "skills",

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -18,7 +18,6 @@ from glob import glob
 from threading import Thread, Event, Lock
 from time import sleep, time, monotonic
 from inspect import signature
-import shutil
 import xdg
 
 from mycroft.api import is_paired
@@ -26,12 +25,12 @@ from mycroft.enclosure.api import EnclosureAPI
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
+from mycroft.util import connected
 from mycroft.util.lang import set_default_lang, load_languages
 from mycroft.skills.msm_wrapper import create_msm as msm_creator, build_msm_config
 from mycroft.skills.settings import SkillSettingsDownloader
 from mycroft.skills.skill_loader import SkillLoader
 from mycroft.skills.skill_updater import SkillUpdater
-
 
 
 SKILL_MAIN_MODULE = '__init__.py'
@@ -86,7 +85,7 @@ class UploadQueue:
             LOG.info('Updating settings meta during runtime...')
         with self.lock:
             # Remove existing loader
-            self._queue == [e for e in self._queue if e != loader]
+            self._queue = [e for e in self._queue if e != loader]
             self._queue.append(loader)
 
 
@@ -128,7 +127,6 @@ class SkillManager(Thread):
         # Set watchdog to argument or function returning None
         self._watchdog = watchdog or (lambda: None)
         self._stop_event = Event()
-        self._connected_event = Event()
         self.config = Configuration.get()
         self.upload_queue = UploadQueue()
 
@@ -155,12 +153,6 @@ class SkillManager(Thread):
         """Define message bus events with handlers defined in this class."""
         # Conversation management
         self.bus.on('skill.converse.request', self.handle_converse_request)
-
-        # Update on initial connection
-        self.bus.on(
-            'mycroft.internet.connected',
-            lambda x: self._connected_event.set()
-        )
 
         # Update upon request
         self.bus.on('skillmanager.update', self.schedule_now)
@@ -235,7 +227,10 @@ class SkillManager(Thread):
     def run(self):
         """Load skills and update periodically from disk and internet."""
         self._remove_git_locks()
-        self._connected_event.wait()
+        if self.skills_config.get("wait_for_internet", True):
+            while not connected():
+                sleep(1)
+
         if (not self.skill_updater.defaults_installed() and
                 self.skills_config["auto_update"]):
             LOG.info('Not all default skills are installed, '
@@ -321,7 +316,6 @@ class SkillManager(Thread):
     def _get_skill_directories(self):
         skill_glob = glob(os.path.join(
             xdg.BaseDirectory.save_data_path('mycroft/skills'), '*/'))
-
         skill_directories = []
         for skill_dir in skill_glob:
             # TODO: all python packages must have __init__.py!  Better way?


### PR DESCRIPTION
mycroft-core simply refuses to start loading skills if internet is not available

this does not work for mycroft-lib, backend is optional, auto updates are optional, there is absolutely no reason to depend on internet connectivity when we have offline STT and the backend only provides a web UI

this make this feature configurable, but enabled by default. the reasoning is that we want to stay as close to mycroft-core as possible, and users need to edit the .conf to disable the need for this anyway