### PR TITLE
feat/configurable_config_path

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 from os.path import abspath, dirname, join
-
+import mycroft.configuration
 from mycroft.api import Api
 from mycroft.messagebus.message import Message
 # don't require adapt to be installed to import non-skill stuff

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -543,4 +543,5 @@ def check_remote_pairing(ignore_errors):
 
 def is_backend_disabled():
     config = Configuration.get(cache=False, remote=False)
-    return config["server"].get("disabled") or False
+    return config.get("server", {}).get("disabled") or False
+

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -31,8 +31,7 @@ import speech_recognition as sr
 
 import requests
 
-from mycroft.configuration import Configuration, LocalConf, get_xdg_base
-from mycroft.configuration.locations import OLD_USER_CONFIG
+from mycroft.configuration import Configuration, get_xdg_base
 from mycroft.util.log import LOG
 from mycroft.util.monotonic_event import MonotonicEvent
 from mycroft.util.plugins import load_plugin
@@ -199,37 +198,6 @@ class PreciseHotword(HotWordEngine):
         from precise_runner import (
             PreciseRunner, PreciseEngine, ReadWriteStream
         )
-
-        conf = Configuration.get(remote=False)
-        if conf.get("disable_xdg"):
-            local_conf = {}
-        else:
-            # We need to save to a writeable location, but the key we need
-            # might be stored in a different, unwriteable, location
-            # Make sure we pick the key we need from wherever it's located,
-            # but save to a writeable location only
-
-            local_conf = LocalConf(join(XDG.xdg_config_home, get_xdg_base(),
-                                        'mycroft.conf'))
-
-            for path in XDG.load_config_paths(get_xdg_base()):
-                conf = LocalConf(join(path, 'mycroft.conf'))
-                # If the current config contains the precise key use it,
-                # otherwise continue to the next file
-                if conf.get('precise', None) is not None:
-                    local_conf['precise'] = conf.get('precise', None)
-                    break
-
-        # If the key is not found yet, it might still exist on the old
-        # (deprecated) location
-        if local_conf.get('precise', None) is None:
-            local_conf = LocalConf(OLD_USER_CONFIG)
-
-        if (local_conf.get('precise', {}).get('dist_url') ==
-                'http://bootstrap.mycroft.ai/artifacts/static/daily/'):
-            del local_conf['precise']['dist_url']
-            local_conf.store()
-            Configuration.updated(None)
 
         self.download_complete = True
 

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -31,7 +31,7 @@ import speech_recognition as sr
 
 import requests
 
-from mycroft.configuration import Configuration, LocalConf
+from mycroft.configuration import Configuration, LocalConf, get_xdg_base
 from mycroft.configuration.locations import OLD_USER_CONFIG
 from mycroft.util.log import LOG
 from mycroft.util.monotonic_event import MonotonicEvent
@@ -209,10 +209,10 @@ class PreciseHotword(HotWordEngine):
             # Make sure we pick the key we need from wherever it's located,
             # but save to a writeable location only
 
-            local_conf = LocalConf(join(XDG.xdg_config_home, 'mycroft',
+            local_conf = LocalConf(join(XDG.xdg_config_home, get_xdg_base(),
                                         'mycroft.conf'))
 
-            for path in XDG.load_config_paths('mycroft'):
+            for path in XDG.load_config_paths(get_xdg_base()):
                 conf = LocalConf(join(path, 'mycroft.conf'))
                 # If the current config contains the precise key use it,
                 # otherwise continue to the next file
@@ -285,7 +285,7 @@ class PreciseHotword(HotWordEngine):
         old_path = join(expanduser('~'), '.mycroft', 'precise')
         if os.path.isdir(old_path):
             return old_path
-        return join(XDG.xdg_data_home, 'mycroft', "precise")
+        return join(XDG.xdg_data_home, get_xdg_base(), "precise")
 
     @property
     def install_destination(self):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -350,12 +350,12 @@ class RecognizerLoop(EventEmitter):
         else:
             LOG.info('Using hotword entry for {}'.format(word))
             if 'phonemes' not in config[word]:
-                LOG.warning('Phonemes are missing falling back to listeners '
-                            'configuration')
+                #LOG.warning('Phonemes are missing falling back to listeners '
+                #            'configuration')
                 config[word]['phonemes'] = phonemes
             if 'threshold' not in config[word]:
-                LOG.warning('Threshold is missing falling back to listeners '
-                            'configuration')
+                #LOG.warning('Threshold is missing falling back to listeners '
+                #            'configuration')
                 config[word]['threshold'] = thresh
 
         return HotWordFactory.create_hotword(word, config, self.lang,

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -16,7 +16,6 @@ import sys
 import io
 from math import ceil
 from xdg import BaseDirectory as XDG
-
 from mycroft.client.text.gui_server import start_qml_gui
 
 from mycroft.tts import TTS
@@ -32,7 +31,7 @@ from threading import Thread, Lock
 from mycroft.messagebus.client import MessageBusClient
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
-from mycroft.configuration import Configuration
+from mycroft.configuration import Configuration, get_xdg_base
 
 import locale
 # Curses uses LC_ALL to determine how to display chars set it to system
@@ -189,12 +188,12 @@ def load_settings():
         LOG.warning(" Note that this location is deprecated and will" +
                     " not be used in the future")
         LOG.warning(" Please move it to " +
-                    os.path.join(XDG.xdg_config_home, 'mycroft', filename))
+                    os.path.join(XDG.xdg_config_home, get_xdg_base(), filename))
         config_file = path
 
     # Check XDG_CONFIG_DIR
     if config_file is None:
-        for p in XDG.load_config_paths('mycroft'):
+        for p in XDG.load_config_paths(get_xdg_base()):
             file = os.path.join(p, filename)
             if os.path.isfile(file):
                 config_file = file
@@ -238,7 +237,7 @@ def save_settings():
     if core_conf.get("disable_xdg"):
         config_file = path
     else:
-        config_file = os.path.join(XDG.xdg_config_home, 'mycroft', filename)
+        config_file = os.path.join(XDG.xdg_config_home, get_xdg_base(), filename)
 
     with io.open(config_file, 'w') as f:
         f.write(str(json.dumps(config, ensure_ascii=False)))

--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG, \
+    set_xdg_base, get_xdg_base, set_config_filename
 from mycroft.configuration.config import Configuration, LocalConf, RemoteConf
-from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG
+

--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG, \
-    set_xdg_base, get_xdg_base, set_config_filename
+    set_xdg_base, get_xdg_base, set_config_filename, get_config_locations, \
+    get_config_filename, get_xdg_config_locations, set_default_config
 from mycroft.configuration.config import Configuration, LocalConf, RemoteConf
 

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -24,6 +24,7 @@ from xdg import BaseDirectory as XDG
 from mycroft.util.json_helper import load_commented_json, merge_dict
 from mycroft.util.log import LOG
 
+from mycroft.configuration import get_xdg_base
 from mycroft.configuration.locations import (DEFAULT_CONFIG, SYSTEM_CONFIG,
                                              OLD_USER_CONFIG, WEB_CONFIG_CACHE,
                                              USER_CONFIG)
@@ -247,7 +248,7 @@ class Configuration:
                 # Then use XDG config
                 # This includes both the user config and
                 # /etc/xdg/mycroft/mycroft.conf
-                for p in XDG.load_config_paths('mycroft'):
+                for p in XDG.load_config_paths(get_xdg_base()):
                     configs.append(LocalConf(join(p, 'mycroft.conf')))
 
                 # Then check the old user config
@@ -260,7 +261,7 @@ class Configuration:
                     LOG.warning(" Note that this location is deprecated and will" +
                                 " not be used in the future")
                     LOG.warning(" Please move it to " +
-                                join(XDG.xdg_config_home, 'mycroft'))
+                                join(XDG.xdg_config_home, get_xdg_base()))
                     configs.append(LocalConf(OLD_USER_CONFIG))
 
                 # Then check the XDG user config

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017 Mycroft AI Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,10 +23,8 @@ from xdg import BaseDirectory as XDG
 from mycroft.util.json_helper import load_commented_json, merge_dict
 from mycroft.util.log import LOG
 
-from mycroft.configuration import get_xdg_base
-from mycroft.configuration.locations import (DEFAULT_CONFIG, SYSTEM_CONFIG,
-                                             OLD_USER_CONFIG, WEB_CONFIG_CACHE,
-                                             USER_CONFIG)
+from mycroft.configuration.locations import get_webcache_location, \
+    get_xdg_config_locations, get_xdg_base, get_config_locations
 
 
 def is_remote_list(values):
@@ -131,8 +128,7 @@ class RemoteConf(LocalConf):
 
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
-
-        cache = cache or WEB_CONFIG_CACHE
+        cache = cache or get_webcache_location()
 
         try:
             # Here to avoid cyclic import
@@ -189,6 +185,17 @@ class RemoteConf(LocalConf):
             self.load_local(cache)
 
 
+def _warn_xdg_config(old_user_config):
+    LOG.warning(" ===============================================")
+    LOG.warning(" ==             DEPRECATION WARNING           ==")
+    LOG.warning(" ===============================================")
+    LOG.warning(f" You still have a config file at {old_user_config}")
+    LOG.warning(" Note that this location is deprecated and will" +
+                " not be used in the future")
+    LOG.warning(" Please move it to " + join(XDG.xdg_config_home,
+                                             get_xdg_base()))
+
+
 class Configuration:
     """Namespace for operations on the configuration singleton."""
     __config = {}  # Cached config
@@ -228,59 +235,40 @@ class Configuration:
         Returns:
             (dict) merged dict of all configuration files
         """
-
         if not configs:
-            configs = configs or []
+            (default_config, web_cache,
+             system_config, old_user_config,
+             user_config) = get_config_locations()
 
-            # first let's load all non XDG configs, and check if XDG is disabled
-            # TODO deprecate this once mycroft-core supports XDG
-            _config = Configuration.load_config_stack(
-                [DEFAULT_CONFIG, SYSTEM_CONFIG, OLD_USER_CONFIG],
-                cache=False, remote=False)
-
-            # First use the patched config
-            configs.append(Configuration.__patch)
-
-            if _config.get("disable_xdg"):
-                # Then check the old user config
-                configs.append(LocalConf(OLD_USER_CONFIG))
+            if remote:
+                configs = [LocalConf(default_config),
+                           LocalConf(system_config),
+                           RemoteConf()]
             else:
-                # Then use XDG config
+                configs = [LocalConf(default_config),
+                           LocalConf(system_config)]
+
+            # HolmesV feature: optional XDG
+            # load all non XDG configs, and check if XDG is disabled
+            # TODO deprecate this once mycroft-core moves to XDG
+            # (or just change default .conf value)
+            _config = Configuration.load_config_stack(
+                [default_config, system_config, old_user_config],
+                cache=False, remote=False)
+            if _config.get("disable_xdg"):
+                # just load the pre defined locations
+                configs += [LocalConf(old_user_config), Configuration.__patch]
+            else:
+                # deprecation warning
+                if isfile(old_user_config):
+                    _warn_xdg_config(old_user_config)
+                    configs.append(LocalConf(old_user_config))
+
                 # This includes both the user config and
                 # /etc/xdg/mycroft/mycroft.conf
-                for p in XDG.load_config_paths(get_xdg_base()):
-                    configs.append(LocalConf(join(p, 'mycroft.conf')))
-
-                # Then check the old user config
-                if isfile(OLD_USER_CONFIG):
-                    LOG.warning(" ===============================================")
-                    LOG.warning(" ==             DEPRECATION WARNING           ==")
-                    LOG.warning(" ===============================================")
-                    LOG.warning(" You still have a config file at " +
-                                OLD_USER_CONFIG)
-                    LOG.warning(" Note that this location is deprecated and will" +
-                                " not be used in the future")
-                    LOG.warning(" Please move it to " +
-                                join(XDG.xdg_config_home, get_xdg_base()))
-                    configs.append(LocalConf(OLD_USER_CONFIG))
-
-                # Then check the XDG user config
-                if isfile(USER_CONFIG):
-                    configs.append(LocalConf(USER_CONFIG))
-
-            # Then use remote config
-            if remote:
-                configs.append(RemoteConf())
-
-            # Then use the system config (/etc/mycroft/mycroft.conf)
-            configs.append(LocalConf(SYSTEM_CONFIG))
-
-            # Then use the config that comes with the package
-            configs.append(LocalConf(DEFAULT_CONFIG))
-
-            # Make sure we reverse the array, as merge_dict will put every new
-            # file on top of the previous one
-            configs = reversed(configs)
+                xdg_confs = [LocalConf(p) for p in get_xdg_config_locations()]
+                configs += xdg_confs + [LocalConf(user_config),
+                                        Configuration.__patch]
         else:
             # Handle strings in stack
             for index, item in enumerate(configs):

--- a/mycroft/configuration/locations.py
+++ b/mycroft/configuration/locations.py
@@ -16,16 +16,50 @@ from time import sleep
 from os.path import join, dirname, expanduser, exists
 from xdg import BaseDirectory as XDG
 
-DEFAULT_CONFIG = join(dirname(__file__), 'mycroft.conf')
+
+# for downstream support, all XDG paths should respect this
+XDG_BASE_FOLDER = "mycroft"
+CONFIG_FILE_NAME = "mycroft.conf"
+
+
+def set_xdg_base(folder_name):
+    global XDG_BASE_FOLDER
+    from mycroft.util.log import LOG
+    LOG.info(f"XDG base folder set to: '{folder_name}'")
+    XDG_BASE_FOLDER = folder_name
+
+
+def set_config_filename(file_name):
+    global CONFIG_FILE_NAME, DEFAULT_CONFIG, SYSTEM_CONFIG, \
+        OLD_USER_CONFIG, USER_CONFIG
+    from mycroft.util.log import LOG
+    LOG.info(f"config filename set to: '{file_name}'")
+    CONFIG_FILE_NAME = file_name
+    DEFAULT_CONFIG = join(dirname(__file__), CONFIG_FILE_NAME)
+    SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
+                                   '/etc/mycroft/' + CONFIG_FILE_NAME)
+    # Make sure we support the old location still
+    # Deprecated and will be removed eventually
+    OLD_USER_CONFIG = join(expanduser('~'), '.mycroft', CONFIG_FILE_NAME)
+    USER_CONFIG = join(XDG.xdg_config_home, XDG_BASE_FOLDER, CONFIG_FILE_NAME)
+    __ensure_folder_exists(USER_CONFIG)
+
+
+def get_xdg_base():
+    global XDG_BASE_FOLDER
+    return XDG_BASE_FOLDER
+
+
+DEFAULT_CONFIG = join(dirname(__file__), CONFIG_FILE_NAME)
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
-                               '/etc/mycroft/mycroft.conf')
+                               '/etc/mycroft/' + CONFIG_FILE_NAME)
 # Make sure we support the old location still
 # Deprecated and will be removed eventually
-OLD_USER_CONFIG = join(expanduser('~'), '.mycroft/mycroft.conf')
-USER_CONFIG = join(XDG.xdg_config_home, 'mycroft', 'mycroft.conf')
+OLD_USER_CONFIG = join(expanduser('~'), '.mycroft', CONFIG_FILE_NAME)
+USER_CONFIG = join(XDG.xdg_config_home, XDG_BASE_FOLDER, CONFIG_FILE_NAME)
 
 REMOTE_CONFIG = "mycroft.ai"
-WEB_CONFIG_CACHE = join(XDG.xdg_config_home, 'mycroft', 'web_cache.json')
+WEB_CONFIG_CACHE = join(XDG.xdg_config_home, XDG_BASE_FOLDER, 'web_cache.json')
 
 
 def __ensure_folder_exists(path):

--- a/mycroft/configuration/locations.py
+++ b/mycroft/configuration/locations.py
@@ -16,50 +16,95 @@ from time import sleep
 from os.path import join, dirname, expanduser, exists
 from xdg import BaseDirectory as XDG
 
-
 # for downstream support, all XDG paths should respect this
-XDG_BASE_FOLDER = "mycroft"
+BASE_FOLDER = "mycroft"
 CONFIG_FILE_NAME = "mycroft.conf"
 
 
 def set_xdg_base(folder_name):
-    global XDG_BASE_FOLDER
+    global BASE_FOLDER, WEB_CONFIG_CACHE
     from mycroft.util.log import LOG
     LOG.info(f"XDG base folder set to: '{folder_name}'")
-    XDG_BASE_FOLDER = folder_name
+    BASE_FOLDER = folder_name
+    WEB_CONFIG_CACHE = join(XDG.xdg_config_home, BASE_FOLDER, 'web_cache.json')
+    __ensure_folder_exists(WEB_CONFIG_CACHE)
 
 
-def set_config_filename(file_name):
-    global CONFIG_FILE_NAME, DEFAULT_CONFIG, SYSTEM_CONFIG, \
-        OLD_USER_CONFIG, USER_CONFIG
+def set_config_filename(file_name, core_folder=None):
+    global CONFIG_FILE_NAME, SYSTEM_CONFIG, OLD_USER_CONFIG, USER_CONFIG, \
+        BASE_FOLDER
     from mycroft.util.log import LOG
+    if core_folder:
+        BASE_FOLDER = core_folder
+        set_xdg_base(core_folder)
     LOG.info(f"config filename set to: '{file_name}'")
     CONFIG_FILE_NAME = file_name
-    DEFAULT_CONFIG = join(dirname(__file__), CONFIG_FILE_NAME)
     SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
-                                   '/etc/mycroft/' + CONFIG_FILE_NAME)
+                                   f'/etc/{BASE_FOLDER}/{CONFIG_FILE_NAME}')
     # Make sure we support the old location still
     # Deprecated and will be removed eventually
-    OLD_USER_CONFIG = join(expanduser('~'), '.mycroft', CONFIG_FILE_NAME)
-    USER_CONFIG = join(XDG.xdg_config_home, XDG_BASE_FOLDER, CONFIG_FILE_NAME)
+    OLD_USER_CONFIG = join(expanduser('~'), '.' + BASE_FOLDER,
+                           CONFIG_FILE_NAME)
+    USER_CONFIG = join(XDG.xdg_config_home, BASE_FOLDER, CONFIG_FILE_NAME)
     __ensure_folder_exists(USER_CONFIG)
 
 
+def set_default_config(file_path):
+    global DEFAULT_CONFIG
+    from mycroft.util.log import LOG
+    DEFAULT_CONFIG = file_path
+    LOG.info(f"default config file changed to: {file_path}")
+
+
 def get_xdg_base():
-    global XDG_BASE_FOLDER
-    return XDG_BASE_FOLDER
+    global BASE_FOLDER
+    return BASE_FOLDER
+
+
+def get_config_locations(default=True, web_cache=True, system=True,
+                         old_user=True, user=True):
+    locs = []
+    if default:
+        locs.append(DEFAULT_CONFIG)
+    if system:
+        locs.append(SYSTEM_CONFIG)
+    if web_cache:
+        locs.append(WEB_CONFIG_CACHE)
+    if old_user:
+        locs.append(OLD_USER_CONFIG)
+    if user:
+        locs.append(USER_CONFIG)
+
+    return locs
+
+
+def get_webcache_location():
+    return join(XDG.xdg_config_home, BASE_FOLDER, CONFIG_FILE_NAME)
+
+
+def get_xdg_config_locations():
+    # This includes both the user config and
+    # /etc/xdg/mycroft/mycroft.conf
+    xdg_paths = list(reversed(
+        [join(p, get_config_filename())
+         for p in XDG.load_config_paths(get_xdg_base())]
+    ))
+    return xdg_paths
+
+
+def get_config_filename():
+    return CONFIG_FILE_NAME
 
 
 DEFAULT_CONFIG = join(dirname(__file__), CONFIG_FILE_NAME)
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
-                               '/etc/mycroft/' + CONFIG_FILE_NAME)
+                               f'/etc/{BASE_FOLDER}/{CONFIG_FILE_NAME}')
 # Make sure we support the old location still
 # Deprecated and will be removed eventually
-OLD_USER_CONFIG = join(expanduser('~'), '.mycroft', CONFIG_FILE_NAME)
-USER_CONFIG = join(XDG.xdg_config_home, XDG_BASE_FOLDER, CONFIG_FILE_NAME)
-
+OLD_USER_CONFIG = join(expanduser('~'), '.' + BASE_FOLDER, CONFIG_FILE_NAME)
+USER_CONFIG = join(XDG.xdg_config_home, BASE_FOLDER, CONFIG_FILE_NAME)
 REMOTE_CONFIG = "mycroft.ai"
-WEB_CONFIG_CACHE = join(XDG.xdg_config_home, XDG_BASE_FOLDER, 'web_cache.json')
+WEB_CONFIG_CACHE = join(XDG.xdg_config_home, BASE_FOLDER, 'web_cache.json')
 
 
 def __ensure_folder_exists(path):

--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -17,6 +17,7 @@ import shutil
 from os.path import join, expanduser, isdir
 from xdg import BaseDirectory as XDG
 from mycroft.configuration import Configuration
+from mycroft.configuration.locations import get_xdg_base
 
 
 class FileSystemAccess:
@@ -36,7 +37,7 @@ class FileSystemAccess:
             raise ValueError("path must be initialized as a non empty string")
 
         old_path = join(expanduser('~'), '.mycroft', path)
-        path = join(XDG.xdg_config_home, 'mycroft', path)
+        path = join(XDG.xdg_config_home, get_xdg_base(), path)
 
         core_conf = Configuration.get(remote=False)
         if core_conf.get("disable_xdg"):

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -23,7 +23,7 @@ from threading import Thread, Lock
 from os.path import isfile, join, expanduser
 from xdg import BaseDirectory as XDG
 
-from mycroft.configuration import Configuration
+from mycroft.configuration import Configuration, get_xdg_base
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 from mycroft.skills.mycroft_skill.event_container import EventContainer, \
@@ -72,7 +72,7 @@ class EventScheduler(Thread):
             self.schedule_file = old_schedule_path
         else:
             new_schedule_path = join(
-                    XDG.load_first_config('mycroft'), schedule_file)
+                    XDG.load_first_config(get_xdg_base()), schedule_file)
             if isfile(old_schedule_path):
                 shutil.move(old_schedule_path, new_schedule_path)
             self.schedule_file = new_schedule_path

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -26,6 +26,7 @@ from xdg import BaseDirectory as XDG
 
 from combo_lock import ComboLock
 from mycroft.util.log import LOG
+from mycroft.configuration import get_xdg_base
 from mock_msm import \
     MycroftSkillsManager as MockMSM, \
     SkillRepo as MockSkillRepo
@@ -114,7 +115,7 @@ def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
     LOG.info('Acquiring lock to instantiate MSM')
     with msm_lock:
         # create folder if needed
-        XDG.save_data_path('mycroft/skills')
+        XDG.save_data_path(get_xdg_base() + '/skills')
 
         msm_skill_repo = repo_clazz(
             msm_config.repo_url,

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -33,7 +33,7 @@ from mycroft.api import DeviceApi
 from mycroft.audio import wait_while_speaking
 from mycroft.enclosure.api import EnclosureAPI
 from mycroft.enclosure.gui import SkillGUI
-from mycroft.configuration import Configuration
+from mycroft.configuration import Configuration, get_xdg_base
 from mycroft.dialog import load_dialogs
 from mycroft.filesystem import FileSystemAccess
 from mycroft.messagebus.message import Message, dig_for_message
@@ -185,7 +185,7 @@ class MycroftSkill:
 
         # Then, check XDG_CONFIG_DIR
         if not settings_read_path.joinpath('settings.json').exists():
-            for path in XDG.load_config_paths('mycroft', 'skills',
+            for path in XDG.load_config_paths(get_xdg_base(), 'skills',
                                               basename(self.root_dir)):
                 path = Path(path)
                 # If there is a settings file here, use it

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -20,7 +20,7 @@ from time import time
 from xdg import BaseDirectory as XDG
 
 from mycroft.api import DeviceApi, is_paired
-from mycroft.configuration import Configuration
+from mycroft.configuration import Configuration, get_xdg_base
 from mycroft.util import connected
 from combo_lock import ComboLock
 from mycroft.util.log import LOG
@@ -101,7 +101,7 @@ class SkillUpdater:
                         '~/.mycroft/.mycroft-skills')
                 else:
                     self._installed_skills_file_path = os.path.join(
-                        XDG.xdg_data_home, 'mycroft', '.mycroft-skills')
+                        XDG.xdg_data_home, get_xdg_base(), '.mycroft-skills')
 
         return self._installed_skills_file_path
 

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -27,7 +27,7 @@ from xdg import BaseDirectory as XDG
 
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.api import DeviceApi
-from mycroft.configuration import Configuration
+from mycroft.configuration import Configuration, get_xdg_base
 from mycroft.util.download import download
 from mycroft.util.log import LOG
 
@@ -60,7 +60,7 @@ def get_subscriber_voices():
     Returns:
         (dict) map of voices to custom Mimic executables.
     """
-    path = join(XDG.xdg_config_home, 'mycroft', 'voices', 'mimic_tn')
+    path = join(XDG.xdg_config_home, get_xdg_base(), 'voices', 'mimic_tn')
     return {'trinity': path}
 
 

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -25,6 +25,7 @@ import tempfile
 from xdg import BaseDirectory as XDG
 
 import mycroft.configuration
+from mycroft.configuration import get_xdg_base
 from mycroft.util.log import LOG
 
 
@@ -59,7 +60,7 @@ def resolve_resource_file(res_name):
         return res_name
 
     # Now look for XDG_DATA_DIRS
-    for path in XDG.load_data_paths('mycroft'):
+    for path in XDG.load_data_paths(get_xdg_base()):
         filename = os.path.join(path, res_name)
         if os.path.isfile(filename):
             return filename
@@ -241,7 +242,7 @@ def get_cache_directory(domain=None):
             # If not defined, use /tmp/mycroft/cache
             directory = os.path.join(tempfile.gettempdir(), "mycroft", "cache")
         else:
-            directory = os.path.join(XDG.xdg_data_home, "mycroft", "cache")
+            directory = os.path.join(XDG.xdg_data_home, get_xdg_base(), "cache")
     return ensure_directory_exists(directory, domain)
 
 

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -33,7 +33,7 @@ import sys
 
 from os.path import isfile, join
 from xdg import BaseDirectory as XDG
-from mycroft.configuration.locations import SYSTEM_CONFIG
+from mycroft.configuration.locations import SYSTEM_CONFIG, get_xdg_base
 from mycroft.util.json_helper import load_commented_json, merge_dict
 
 
@@ -85,7 +85,7 @@ class LOG:
         # used since it uses the LOG system and would cause horrible cyclic
         # dependencies.
         confs = [SYSTEM_CONFIG]
-        for path in XDG.load_config_paths('mycroft'):
+        for path in XDG.load_config_paths(get_xdg_base()):
             confs.append(join(path, 'mycroft.conf'))
 
         config = {}

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -31,9 +31,9 @@ import inspect
 import logging
 import sys
 
-from os.path import isfile, join
-from xdg import BaseDirectory as XDG
-from mycroft.configuration.locations import SYSTEM_CONFIG, get_xdg_base
+from os.path import isfile
+from mycroft.configuration.locations import get_xdg_config_locations, \
+    get_config_locations
 from mycroft.util.json_helper import load_commented_json, merge_dict
 
 
@@ -84,9 +84,8 @@ class LOG:
         # Check configs manually, the Mycroft configuration system can't be
         # used since it uses the LOG system and would cause horrible cyclic
         # dependencies.
-        confs = [SYSTEM_CONFIG]
-        for path in XDG.load_config_paths(get_xdg_base()):
-            confs.append(join(path, 'mycroft.conf'))
+        default_config, _, system_config, _, _ = get_config_locations()
+        confs = [default_config, system_config] + get_xdg_config_locations()
 
         config = {}
         for conf in confs:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HolmesV',
-    version="2021.5.6a13",
+    version="2021.5.6a14",
     license='Apache-2.0',
     url='https://github.com/HelloChatterbox/HolmesV',
     description='mycroft-core packaged as a library you can rely on',


### PR DESCRIPTION
allow downstream projects to name their config file as they wish

multiple cores should be able to co-exist (as long as they are in different .venv)

in the wild there are projects monkey patching mycroft because of this, makes more sense to expose a proper API for it