### PR TITLE
skill_id in message.context

### DIFF
--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -404,6 +404,7 @@ class CommonIoTSkill(MycroftSkill, ABC):
         if can_handle:
             data.update({"skill_id": self.skill_id,
                          "callback_data": callback_data})
+            message.context["skill_id"] = self.skill_id
             self.bus.emit(message.response(data))
 
     @_track_request
@@ -423,6 +424,7 @@ class CommonIoTSkill(MycroftSkill, ABC):
     def speak(self, utterance, *args, **kwargs):
         if self._current_iot_request:
             message = dig_for_message()
+            message.context["skill_id"] = self.skill_id
             self.bus.emit(message.forward(_BusKeys.SPEAK,
                                           data={"skill_id": self.skill_id,
                                                 IOT_REQUEST_ID:
@@ -459,7 +461,8 @@ class CommonIoTSkill(MycroftSkill, ABC):
             self.bus.emit(Message(_BusKeys.REGISTER,
                                   data={"skill_id": self.skill_id,
                                         "type": word_type,
-                                        "words": list(words)}))
+                                        "words": list(words)},
+                                  context={"skill_id": self.skill_id}))
 
     def register_entities_and_scenes(self):
         """

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -85,7 +85,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
     def __handle_play_query(self, message):
         """Query skill if it can start playback from given phrase."""
         search_phrase = message.data["phrase"]
-
+        message.context["skill_id"] = self.skill_id
         # First, notify the requestor that we are attempting to handle
         # (this extends a timeout while this skill looks for a match)
         self.bus.emit(message.response({"phrase": search_phrase,
@@ -159,6 +159,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # Stop any currently playing audio
         if self.audioservice.is_playing:
             self.audioservice.stop()
+        message.context["skill_id"] = self.skill_id
         self.bus.emit(message.forward("mycroft.stop"))
 
         # Save for CPS_play() later, e.g. if phrase includes modifiers like

--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -65,7 +65,7 @@ class CommonQuerySkill(MycroftSkill, ABC):
 
     def __handle_question_query(self, message):
         search_phrase = message.data["phrase"]
-
+        message.context["skill_id"] = self.skill_id
         # First, notify the requestor that we are attempting to handle
         # (this extends a timeout while this skill looks for a match)
         self.bus.emit(message.response({"phrase": search_phrase,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HolmesV',
-    version="2021.5.6a11",
+    version="2021.5.6a12",
     license='Apache-2.0',
     url='https://github.com/HelloChatterbox/HolmesV',
     description='mycroft-core packaged as a library you can rely on',


### PR DESCRIPTION
ensure all messages emitted by skills include the skill_id in the message.context

this is very useful for message routing (eg, hivemind), state tracking (eg, converse tracker in ovos_utils) and general debugging (eg, chatterbox_monitor)