### PR TITLE
fix get_response default_fail dialog missing

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -767,6 +767,8 @@ class MycroftSkill:
         Returns:
             str: A randomly chosen string from the file
         """
+        if self.dialog_renderer is None:
+            return ""
         return self.dialog_renderer.render(text, data or {})
 
     def find_resource(self, res_name, res_dirname=None):


### PR DESCRIPTION
#5 missed the case in the default on_fail dialog

this should now ensure MycroftSkill handles skills with no dialog folder correctly