### PR TITLE
feat/skill permissions

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -136,7 +136,22 @@
     // of unknown intent handling for default_skills + user preferences
     "fallback_priorities": {
        // "skill_id": 10
-    }
+    },
+    // fallback skill handling has 3 modes of operations:
+    // - "accept_all"  # default mycroft-core behavior
+    // - "whitelist"  # only call fallback for skills in "fallback_whitelist"
+    // - "blacklist"  # only call fallback for skills NOT in "fallback_blacklist"
+    "fallback_mode": "accept_all",
+    "fallback_whitelist": [],
+    "fallback_blacklist": [],
+
+    // conversational mode has 3 modes of operations:
+    // - "accept_all"  # default mycroft-core behavior
+    // - "whitelist"  # only call converse for skills in "converse_whitelist"
+    // - "blacklist"  # only call converse for skills NOT in "converse_blacklist"
+    "converse_mode": "accept_all",
+    "converse_whitelist": [],
+    "converse_blacklist": []
 
   },
 

--- a/mycroft/skills/permissions.py
+++ b/mycroft/skills/permissions.py
@@ -1,0 +1,20 @@
+"""
+mode of operation is defined in the .conf file for the different components
+"""
+import enum
+
+
+class ConverseMode(str, enum.Enum):
+    ACCEPT_ALL = "accept_all"  # default mycroft-core behavior
+    WHITELIST = "whitelist"  # only call converse for skills in whitelist
+                             # "whitelist": [skill_id]
+    BLACKLIST = "blacklist"  # only call converse for skills NOT in blacklist
+                             # "blacklist": [skill_id]
+
+
+class FallbackMode(str, enum.Enum):
+    ACCEPT_ALL = "accept_all"  # default mycroft-core behavior
+    WHITELIST = "whitelist"  # only call fallback for skills in whitelist
+                             # "whitelist": [skill_id]
+    BLACKLIST = "blacklist"  # only call fallback for skills NOT in blacklist
+                             # "blacklist": [skill_id]


### PR DESCRIPTION
```python
"""
mode of operation is defined in the .conf file for the different components
"""
import enum


class ConverseMode(str, enum.Enum):
    ACCEPT_ALL = "accept_all"  # default mycroft-core behavior
    WHITELIST = "whitelist"  # only call converse for skills in whitelist
                             # "whitelist": [skill_id]
    BLACKLIST = "blacklist"  # only call converse for skills NOT in blacklist
                             # "blacklist": [skill_id]


class FallbackMode(str, enum.Enum):
    ACCEPT_ALL = "accept_all"  # default mycroft-core behavior
    WHITELIST = "whitelist"  # only call fallback for skills in whitelist
                             # "whitelist": [skill_id]
    BLACKLIST = "blacklist"  # only call fallback for skills NOT in blacklist
                             # "blacklist": [skill_id]

```