### PR TITLE
msm support for skills directory

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -100,6 +100,11 @@
 
   // General skill values
   "skills": {
+    // if this is a string it will override the path used to load skills
+    // this allows power users, devs, and distro packagers to choose a
+    // different folder
+    "directory_override": false,
+
     // don't start loading skills until internet is detected
     // this config value is not present in mycroft-core ()internet is required)
     // mycroft-lib expects that some instances will be running fully offline

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -26,7 +26,7 @@ from xdg import BaseDirectory as XDG
 
 from combo_lock import ComboLock
 from mycroft.util.log import LOG
-from mycroft.configuration import get_xdg_base
+from mycroft.configuration import get_xdg_base, Configuration
 from mock_msm import \
     MycroftSkillsManager as MockMSM, \
     SkillRepo as MockSkillRepo
@@ -114,19 +114,37 @@ def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
     msm_lock = _init_msm_lock()
     LOG.info('Acquiring lock to instantiate MSM')
     with msm_lock:
-        # create folder if needed
-        XDG.save_data_path(get_xdg_base() + '/skills')
+        # if xdg is enabled, respect it!
+        conf = Configuration.get(remote=False)
+        if conf.get("disable_xdg"):
+            xdg_skills = None
+        else:
+            # create folder if needed
+            xdg_skills = XDG.save_data_path(get_xdg_base() + '/skills')
 
         msm_skill_repo = repo_clazz(
             msm_config.repo_url,
             msm_config.repo_branch
         )
-        msm_instance = msm_clazz(
-            platform=msm_config.platform,
-            old_skills_dir=msm_config.old_skills_dir,
-            repo=msm_skill_repo,
-            versioned=msm_config.versioned
-        )
+        # NOTE older versions of msm do not have old_skills_dir param
+        # let's support that just in case, mycroft did a mess with msm,
+        # it supports XDG but core doesnt, so there was a release of msm
+        # after the xdg release that removes it???
+        try:
+            msm_instance = msm_clazz(
+                platform=msm_config.platform,
+                old_skills_dir=msm_config.old_skills_dir,
+                repo=msm_skill_repo,
+                skills_dir=xdg_skills,
+                versioned=msm_config.versioned
+            )
+        except:
+            msm_instance = msm_clazz(
+                platform=msm_config.platform,
+                repo=msm_skill_repo,
+                skills_dir=xdg_skills,
+                versioned=msm_config.versioned
+            )
     LOG.info('Releasing MSM instantiation lock.')
 
     return msm_instance

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -114,13 +114,18 @@ def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
     msm_lock = _init_msm_lock()
     LOG.info('Acquiring lock to instantiate MSM')
     with msm_lock:
-        # if xdg is enabled, respect it!
+
         conf = Configuration.get(remote=False)
-        if conf.get("disable_xdg"):
-            xdg_skills = None
+        path_override = conf["skills"].get("directory_override")
+        # if .conf wants to use a specific path, use it!
+        if path_override:
+            skills_folder = path_override
+        # if xdg is enabled, respect it!
+        elif conf.get("disable_xdg"):
+            skills_folder = None
         else:
             # create folder if needed
-            xdg_skills = XDG.save_data_path(get_xdg_base() + '/skills')
+            skills_folder = XDG.save_data_path(get_xdg_base() + '/skills')
 
         msm_skill_repo = repo_clazz(
             msm_config.repo_url,
@@ -135,14 +140,14 @@ def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
                 platform=msm_config.platform,
                 old_skills_dir=msm_config.old_skills_dir,
                 repo=msm_skill_repo,
-                skills_dir=xdg_skills,
+                skills_dir=skills_folder,
                 versioned=msm_config.versioned
             )
         except:
             msm_instance = msm_clazz(
                 platform=msm_config.platform,
                 repo=msm_skill_repo,
-                skills_dir=xdg_skills,
+                skills_dir=skills_folder,
                 versioned=msm_config.versioned
             )
     LOG.info('Releasing MSM instantiation lock.')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
                       "inflection",
                       "psutil",
                       "combo_lock",
-                      "mock_msm",
+                      "mock_msm>=0.9.2",
                       "python-dateutil==2.6.0",
                       "requests-futures"],
     extras_require={


### PR DESCRIPTION
companion to #33 

downstream projects may now change the skills folder instead of being forced to use `"mycroft"` XDG directory, this PR allows several cores to co-exist in same machine

also allows users/devs/distros to define any path to be used regardless of xdg settings


NOTE: older versions of msm do not have old_skills_dir param, mycroft did a mess with msm, it supports XDG ( https://github.com/MycroftAI/mycroft-skills-manager/releases/tag/release%2Fv0.9.0 ) but core doesnt, so there was another release of msm reverting xdg support  ( https://github.com/MycroftAI/mycroft-skills-manager/releases/tag/release%2Fv0.8.9 ), this PR adds support for both XDG and non-XDG compliant msm versions