### PR TITLE
stop

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1324,23 +1324,14 @@ class MycroftSkill:
         """Handler for the "mycroft.stop" signal. Runs the user defined
         `stop()` method.
         """
-        def __stop_timeout():
-            # The self.stop() call took more than 100ms, assume it handled Stop
-            self.bus.emit(Message('mycroft.stop.handled',
-                                  {'skill_id': str(self.skill_id) + ':'},
-                                  {"skill_id": self.skill_id}))
-
-        timer = Timer(0.1, __stop_timeout)  # set timer for 100ms
         try:
             if self.stop():
                 self.bus.emit(Message("mycroft.stop.handled",
                                       {"by": "skill:" + self.skill_id},
                                       {"skill_id": self.skill_id}))
-            timer.cancel()
-        except Exception:
-            timer.cancel()
-            LOG.error('Failed to stop skill: {}'.format(self.name),
-                      exc_info=True)
+        except Exception as e:
+            LOG.exception(e)
+            LOG.error(f'Failed to stop skill: {self.name}')
 
     def stop(self):
         """Optional method implemented by subclass."""

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -306,11 +306,16 @@ class SkillLoader:
                 self.instance.register_resting_screen()
                 self.instance.initialize()
             except Exception as e:
-                # If an exception occurs, make sure to clean up the skill
-                self.instance.default_shutdown()
+                LOG.exception(f'Skill initialization failed: {e}')
+                # If an exception occurs, attempt to clean up the skill
+                try:
+                    self.instance.default_shutdown()
+                except Exception as e2:
+                    # if initialize failed then it's likely
+                    # default_shutdown will fail
+                    LOG.debug(f'Skill cleanup failed: {e2}')
+                    LOG.debug(f'this is usually fine and often expected')
                 self.instance = None
-                log_msg = 'Skill initialization failed with {}'
-                LOG.exception(log_msg.format(repr(e)))
 
         return self.instance is not None
 


### PR DESCRIPTION
in mycroft-core the following assumption is made `# The self.stop() call took more than 100ms, assume it handled Stop`

I personally disagree with this, either stop was handled or it wasnt, no unsafe assumptions, this removes the timeout, but maybe it would be better to actually raise an exception on timeout?

additionally when an exception is raised in `initialize` the `shutdown`/`stop` methods are called, and throw yet another exception, since the skill did not finish loading it is expected these calls will fail, this is also handled in this PR