### PR TITLE
fix/ipc_permissions

### DIFF
--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -253,7 +253,7 @@ def ensure_directory_exists(directory, domain=None, permissions=0o777):
         directory (str): Root directory
         domain (str): Domain. Basically a subdirectory to prevent things like
                       overlapping signal filenames.
-        rights (int): Directory permissions (default is 0o777)
+        permissions (int): Directory permissions (default is 0o777)
 
     Returns:
         (str) a path to the directory
@@ -266,8 +266,8 @@ def ensure_directory_exists(directory, domain=None, permissions=0o777):
     directory = os.path.expanduser(directory)
 
     if not os.path.isdir(directory):
+        save = os.umask(0)
         try:
-            save = os.umask(0)
             os.makedirs(directory, permissions)
         except OSError:
             LOG.warning("Failed to create: " + directory)
@@ -286,3 +286,5 @@ def create_file(filename):
     ensure_directory_exists(os.path.dirname(filename), permissions=0o775)
     with open(filename, 'w') as f:
         f.write('')
+    os.chmod(filename, 0o777)
+

--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -19,6 +19,7 @@ import os
 import os.path
 
 import mycroft
+from mycroft.configuration import get_xdg_base
 from mycroft.util.file_utils import ensure_directory_exists, create_file
 
 
@@ -39,7 +40,7 @@ def get_ipc_directory(domain=None):
     dir = config.get("ipc_path")
     if not dir:
         # If not defined, use /tmp/mycroft/ipc
-        dir = os.path.join(tempfile.gettempdir(), "mycroft", "ipc")
+        dir = os.path.join(tempfile.gettempdir(), get_xdg_base(), "ipc")
     return ensure_directory_exists(dir, domain)
 
 


### PR DESCRIPTION
if a signal is created by a root user (eg, enclosure might be root) then other processes wont have permissions to delete it

the default ipc path if not set is tmp, it was not respecting the settings for base folder name (it is not configurable, was using hardcoded "mycroft")