### PR TITLE
refactor/optional_msm_config

### DIFF
--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -94,17 +94,19 @@ def build_msm_config(device_config: dict) -> MsmConfig:
     ensure that changes to configs not related to MSM will not result in new
     instances of MSM being created.
     """
-    msm_config = device_config['skills']['msm']
-    msm_repo_config = msm_config['repo']
-    enclosure_config = device_config['enclosure']
-    data_dir = path.expanduser(device_config['data_dir'])
+    msm_config = device_config['skills'].get('msm', {"disabled": True})
+    msm_repo_config = msm_config.get('repo', {})
+    enclosure_config = device_config.get('enclosure', "generic")
+    data_dir = path.expanduser(device_config.get('data_dir', "/opt/mycroft"))
 
     return MsmConfig(
         platform=enclosure_config.get('platform', 'default'),
-        repo_branch=msm_repo_config['branch'],
-        repo_url=msm_repo_config['url'],
-        old_skills_dir=path.join(data_dir, msm_config['directory']),
-        versioned=msm_config['versioned'],
+        repo_branch=msm_repo_config.get('branch', "dev"),
+        repo_url=msm_repo_config.get(
+            'url', "https://github.com/MycroftAI/mycroft-skills"),
+        old_skills_dir=path.join(
+            data_dir, msm_config.get('directory', "skills")),
+        versioned=msm_config.get('versioned', False),
         disabled=msm_config.get("disabled", False)
     )
 

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -376,7 +376,7 @@ class SkillManager(Thread):
         """Update skills once an hour if update is enabled"""
         do_skill_update = (
             time() >= self.skill_updater.next_download and
-            self.skills_config["auto_update"]
+            self.skills_config.get("auto_update", False)
         )
         if do_skill_update:
             self.skill_updater.update_skills()

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -50,7 +50,7 @@ class SkillUpdater:
         self.msm_lock = ComboLock('/tmp/mycroft-msm.lck')
         self.install_retries = 0
         self.config = Configuration.get()
-        update_interval = self.config['skills']['update_interval']
+        update_interval = self.config['skills'].get('update_interval', 1.0)
         self.update_interval = int(update_interval) * ONE_HOUR
         self.dot_msm_path = os.path.join(self.msm.skills_dir, '.msm')
         self.next_download = self._determine_next_download_time()


### PR DESCRIPTION
even if disabled the "msm" section was mandatory in the .conf file, this forced downstream projects to include this and caused confusion when msm was not intended to be used at all

this PR makes the section fully optional, and disables msm if skills.msm section is not present in the .conf