### PR TITLE
log polution

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -89,8 +89,7 @@ def get_local_settings(skill_dir, skill_name) -> dict:
                 skill_settings = json.loads(settings_file_content)
             # TODO change to check for JSONDecodeError in 19.08
             except Exception:
-                log_msg = 'Failed to load {} settings from settings.json'
-                LOG.exception(log_msg.format(skill_name))
+                LOG.error(f'Failed to load {skill_name} settings from settings.json')
 
     return skill_settings
 
@@ -109,8 +108,7 @@ def save_settings(skill_dir, skill_settings):
         try:
             json.dump(skill_settings, settings_file)
         except Exception:
-            LOG.exception('error saving skill settings to '
-                          '{}'.format(settings_path))
+            LOG.error(f'error saving skill settings to {settings_path}')
         else:
             LOG.info('Skill settings successfully saved to '
                      '{}' .format(settings_path))
@@ -274,8 +272,7 @@ class SettingsMetaUploader:
                 else:
                     self.settings_meta = yaml.safe_load(meta_file)
         except Exception:
-            log_msg = "Failed to load settingsmeta file: "
-            LOG.exception(log_msg + str(self.settings_meta_path))
+            LOG.error(f"Failed to load settingsmeta file: {self.settings_meta_path}")
 
     def _update_settings_meta(self):
         """Make sure the skill gid and name are included in settings meta.
@@ -305,14 +302,10 @@ class SettingsMetaUploader:
         """Use the API to send the settings meta to the server."""
         try:
             self.api.upload_skill_metadata(self.settings_meta)
-        except Exception:
-            LOG.exception('Failed to upload skill settings meta '
-                          'for {}'.format(self.skill_gid))
-            success = False
-        else:
-            success = True
-
-        return success
+        except Exception as e:
+            LOG.error(f'Failed to upload skill settings meta for {self.skill_gid}')
+            return False
+        return True
 
 
 # Path to remote cache
@@ -422,7 +415,7 @@ class SkillSettingsDownloader:
         try:
             remote_settings = self.api.get_skill_settings()
         except Exception:
-            LOG.exception('Failed to download remote settings from server.')
+            LOG.error('Failed to download remote settings from server.')
             remote_settings = None
 
         return remote_settings
@@ -434,7 +427,7 @@ class SkillSettingsDownloader:
             try:
                 previous_settings = self.last_download_result.get(skill_gid)
             except Exception:
-                LOG.exception('error occurred handling setting change events')
+                LOG.error('error occurred handling setting change events')
             else:
                 if previous_settings != skill_settings:
                     settings_changed = True

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -196,16 +196,18 @@ class SkillUpdater:
             LOG.error('Failed to update skills: {}'.format(repr(e)))
 
     def post_manifest(self, reload_skills_manifest=False):
-        """Post the manifest of the device's skills to the backend."""
+        """Post the manifest of the device's skills to the backend.
+        If msm is disabled nothing is uploaded, skill state is MSM specific"""
         upload_allowed = self.config['skills'].get('upload_skill_manifest')
-        if upload_allowed and is_paired():
+        use_msm = self.config['skills'].get('msm', {}).get("disabled", True)
+        if upload_allowed and use_msm and is_paired():
             if reload_skills_manifest:
                 self.msm.clear_cache()
             try:
                 device_api = DeviceApi()
                 device_api.upload_skills_data(self.msm.device_skill_state)
             except Exception:
-                LOG.exception('Could not upload skill manifest')
+                LOG.error('Could not upload skill manifest')
 
     def install_or_update(self, skill):
         """Install missing defaults and update existing skills"""


### PR DESCRIPTION
skill state is a MSM specific concept, it was still being uploaded with msm disabled

this caused a bunch of errors logs when uploading settings meta due to selene backend not knowing about it

all setting related LOGs have been downgraded from exception to error level to avoid LOG spam, the stacktrace is not useful at all since the error is backend side