### PR TITLE
fix TTS engines

### DIFF
--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -370,7 +370,11 @@ class TTS(metaclass=ABCMeta):
                 #  of the TTS cache.  But this requires changing the public
                 #  API of the get_tts method in each engine.
                 audio_file = self.cache.define_audio_file(sentence_hash)
-                _, phonemes = self.get_tts(sentence, str(audio_file.path))
+                # update path in case the TTS engine did not use the
+                # requested path, if file was created in other location we
+                # don't want to duplicate it
+                audio_file.path, phonemes = self.get_tts(sentence,
+                                                         str(audio_file.path))
                 if phonemes:
                     phoneme_file = self.cache.define_phoneme_file(
                         sentence_hash
@@ -382,8 +386,18 @@ class TTS(metaclass=ABCMeta):
                     audio_file, phoneme_file
                 )
             viseme = self.viseme(phonemes) if phonemes else None
+
+            # tts engine has a default audio extension, but we can not be
+            # sure that the file actually uses the same extension,
+            # for instance a mp3 engine might include some cache in wav format
+            # cached utterances might also be saved by the user in the
+            # resources directory
+            if not audio_file.path.endswith(self.audio_ext):
+                audio_ext = audio_file.path.split(".")[-1]
+            else:
+                audio_ext = self.audio_ext
             self.queue.put(
-                (self.audio_ext, str(audio_file.path), viseme, ident, l)
+                (audio_ext, str(audio_file.path), viseme, ident, l)
             )
 
     def _get_sentence_from_cache(self, sentence_hash):


### PR DESCRIPTION
the latest cache refactor introduced an issue in TTS handling, a file path is requested, but TTS engines return the path where the file was created, mycroft is discarding this path and using the originally requested path instead, meaning the file might not exist when playback starts, this PR restores this ability for individual TTS engines

issue introduced in https://github.com/MycroftAI/mycroft-core/pull/2853


tts engine has a default audio extension, but we can not be sure that the file actually uses the same extension, for instance in chatterbox a mp3 engine might include some cache in wav format, cached utterances might also be saved by the user in the resources directory

This PR checks that the returned path match the default extension, and if it doesn't changes it appropriately

